### PR TITLE
docs: 更新 Docker Compose 命令为 v2 语法

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ MESHY_API_KEY=your_meshy_api_key_here
 
 ```bash
 # 启动 Redis 服务
-docker-compose up -d
+docker compose up -d
 
 # 查看服务状态
-docker-compose ps
+docker compose ps
 
 # 查看日志
-docker-compose logs -f redis
+docker compose logs -f redis
 ```
 
 #### 验证 Redis 服务
@@ -104,10 +104,10 @@ docker exec -it 3dprint-redis redis-cli ping
 
 ```bash
 # 停止所有服务
-docker-compose down
+docker compose down
 
 # 停止服务并删除数据卷
-docker-compose down -v
+docker compose down -v
 ```
 
 ## 📁 项目结构


### PR DESCRIPTION
- 将 docker-compose 命令更新为 docker compose
- 修复在 Docker Compose v2 环境下的命令不兼容问题
- 保持文档与前置要求(Docker Compose 2.20+)的一致性

🤖 Generated with [Claude Code](https://claude.com/claude-code)