### PR TITLE
fix: 修复后端服务启动失败的问题

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ pytest-asyncio==0.24.0
 celery==5.4.0
 redis==5.0.8
 flower==2.0.1
+python-multipart==0.0.9

--- a/backend/src/api/v1/routers/tasks.py
+++ b/backend/src/api/v1/routers/tasks.py
@@ -10,8 +10,8 @@ from typing import Any
 from celery.result import AsyncResult
 from fastapi import APIRouter, HTTPException, Path, status
 
-from api.v1.schemas.task import TaskStatusResponse, TaskSubmitRequest, TaskSubmitResponse
-from infrastructure.tasks.celery_app import celery_app
+from src.api.v1.schemas.task import TaskStatusResponse, TaskSubmitRequest, TaskSubmitResponse
+from src.infrastructure.tasks.celery_app import celery_app
 
 router = APIRouter(prefix="/tasks", tags=["Tasks"])
 
@@ -144,7 +144,7 @@ async def submit_delayed_test_task(
     Returns:
         TaskSubmitResponse: 任务提交响应
     """
-    from infrastructure.tasks.test_tasks import delayed_return
+    from src.infrastructure.tasks.test_tasks import delayed_return
 
     task_result = delayed_return.delay(delay_seconds, message)
 

--- a/backend/src/infrastructure/tasks/__init__.py
+++ b/backend/src/infrastructure/tasks/__init__.py
@@ -4,6 +4,6 @@
 Celery 任务队列配置和任务注册
 """
 
-from infrastructure.tasks.celery_app import celery_app
+from src.infrastructure.tasks.celery_app import celery_app
 
 __all__ = ["celery_app"]

--- a/backend/src/infrastructure/tasks/celery_app.py
+++ b/backend/src/infrastructure/tasks/celery_app.py
@@ -7,7 +7,7 @@ Celery 应用配置模块。
 from celery import Celery
 from celery.signals import task_failure, task_success
 
-from infrastructure.config.settings import settings
+from src.infrastructure.config.settings import settings
 
 celery_app = Celery(
     "3d_print_platform",

--- a/backend/src/infrastructure/tasks/test_tasks.py
+++ b/backend/src/infrastructure/tasks/test_tasks.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from celery import Task
 
-from infrastructure.tasks.celery_app import celery_app
+from src.infrastructure.tasks.celery_app import celery_app
 
 
 @celery_app.task(bind=True, name="test_tasks.delayed_return")


### PR DESCRIPTION
- 添加缺失的依赖 python-multipart (文件上传功能必需)
- 修复所有模块导入路径，统一添加 src. 前缀
- 修复文件列表:
  - backend/src/api/v1/routers/tasks.py
  - backend/src/infrastructure/tasks/celery_app.py
  - backend/src/infrastructure/tasks/test_tasks.py
  - backend/src/infrastructure/tasks/__init__.py

验证: 服务器可以正常启动并响应健康检查请求

🤖 Generated with [Claude Code](https://claude.com/claude-code)