### PR TITLE
fix: 修复 CORS 配置解析错误导致服务启动失败

### DIFF
--- a/backend/src/infrastructure/config/settings.py
+++ b/backend/src/infrastructure/config/settings.py
@@ -4,9 +4,9 @@
 使用 pydantic-settings 管理环境变量和应用配置。
 """
 
-from typing import Literal
+from typing import Literal, Union
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
+        # 禁用自动 JSON 解析,使用 field_validator 手动处理
+        env_parse_none_str=None,
     )
 
     app_name: str = Field(default="3D Print Platform API", description="应用名称")
@@ -34,10 +36,29 @@ class Settings(BaseSettings):
     host: str = Field(default="0.0.0.0", description="服务监听地址")
     port: int = Field(default=8000, description="服务监听端口")
 
-    cors_origins: list[str] = Field(
-        default=["http://localhost:5173", "http://localhost:3000"],
-        description="CORS 允许的源",
+    cors_origins: Union[str, list[str]] = Field(
+        default="http://localhost:5173,http://localhost:3000",
+        description="CORS 允许的源(逗号分隔的字符串或列表)",
     )
+
+    @field_validator("cors_origins", mode="after")
+    @classmethod
+    def parse_cors_origins(cls, v):
+        """
+        解析 CORS 源配置。
+
+        支持逗号分隔的字符串或列表。
+
+        Args:
+            v: 环境变量值
+
+        Returns:
+            list[str]: 解析后的源列表
+        """
+        if isinstance(v, str):
+            # 如果是逗号分隔的字符串,拆分为列表
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
 
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
         default="INFO", description="日志级别"


### PR DESCRIPTION
- 修改 cors_origins 字段类型为 Union[str, list[str]]
- 添加 field_validator 支持逗号分隔的字符串格式
- 解决 Pydantic Settings 尝试将字符串解析为 JSON 的问题
- 现在支持环境变量格式: CORS_ORIGINS=http://localhost:5173,http://localhost:3000

修复前错误:
pydantic_settings.sources.SettingsError: error parsing value for field "cors_origins" from source "EnvSettingsSource"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
